### PR TITLE
made changes

### DIFF
--- a/torat_server/server.go
+++ b/torat_server/server.go
@@ -61,7 +61,7 @@ func Start() error {
 	if err != nil {
 		return err
 	}
-	log.Println("Onion service running:", service.ID+".onoin")
+	log.Println("Onion service running:", service.ID+".onion")
 
 	for {
 		conn, err := service.Accept()


### PR DESCRIPTION
Fixed typo on line 64  from log.Println("Onion service running:", service.ID+".onoin") to  ===> log.Println("Onion service running:", service.ID+".onion")