### PR TITLE
Fixes issue #173 and #140

### DIFF
--- a/torat_client/netclient.go
+++ b/torat_client/netclient.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"log"
 	"net"
+	"net/rpc"
 	"time"
 
 	"github.com/cretz/bine/process/embedded"
@@ -43,8 +44,15 @@ func NetClient() {
 		return
 	}
 
+	api := new(API)
+	rpc_err := rpc.Register(api)
+	if rpc_err != nil {
+		log.Fatal(rpc_err)
+	}
+
 	defer t.Close()
 	dialer, _ := t.Dialer(nil, nil)
+
 	for {
 		conn, err := connect(dialer)
 		if err != nil {
@@ -52,6 +60,6 @@ func NetClient() {
 			time.Sleep(10 * time.Second)
 			continue
 		}
-		RPC(conn)
+		rpc.ServeConn(conn)
 	}
 }

--- a/torat_client/netclient_notor.go
+++ b/torat_client/netclient_notor.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"log"
 	"net"
+	"net/rpc"
 	"time"
 )
 
@@ -30,6 +31,13 @@ func connect() (net.Conn, error) {
 func NetClient() {
 	log.Println("NetClient")
 	initServer()
+
+	api := new(API)
+	rpc_err := rpc.Register(api)
+	if rpc_err != nil {
+		log.Fatal(rpc_err)
+	}
+
 	for {
 		conn, err := connect()
 		if err != nil {
@@ -37,7 +45,6 @@ func NetClient() {
 			time.Sleep(10 * time.Second)
 			continue
 		}
-
-		RPC(conn)
+		rpc.ServeConn(conn)
 	}
 }

--- a/torat_client/rpcapi.go
+++ b/torat_client/rpcapi.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"image/png"
 	"io/ioutil"
-	"log"
-	"net"
-	"net/rpc"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -126,12 +123,3 @@ func (a *API) Cd(path string, r *shared.Dir) (err error) {
 
 // Make sure API is never garbled.
 var _ = reflect.TypeOf(API(0))
-
-func RPC(c net.Conn) {
-	api := new(API)
-	err := rpc.Register(api)
-	if err != nil {
-		log.Fatal(err)
-	}
-	rpc.ServeConn(c)
-}


### PR DESCRIPTION
This was actually a pretty quick fix. Because of the way that `RPC` was defined, when reconnecting to a server the client tries to re-register the API. This results in a fatal error. By putting the `RPC` definition before the for-loop that dials the address, the issue is totally resolved. 