### PR TITLE
Update Dockerfile to use garble 0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM lu4p/tor-static:latest
-RUN go install mvdan.cc/garble@master
+RUN go install mvdan.cc/garble@v0.3.0
 RUN mkdir /ToRat
 WORKDIR /ToRat
 COPY go.mod .


### PR DESCRIPTION
Garble v0.4.0 dropped support for go 1.16.

v0.3.0 supports 1.16.


This should fix https://github.com/lu4p/ToRat/issues/259.